### PR TITLE
Versions and cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.22.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.11</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import edu.wisc.library.ocfl.api.OcflObjectUpdater;
-import edu.wisc.library.ocfl.api.OcflObjectVersion;
 import edu.wisc.library.ocfl.api.OcflOption;
 import edu.wisc.library.ocfl.api.OcflRepository;
 import edu.wisc.library.ocfl.api.model.FileChangeType;
@@ -326,12 +325,7 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
         try {
             if (!(deleteObject && isOpen())) {
                 if (ocflRepo.containsObject(ocflObjectId)) {
-                    final OcflObjectVersion object;
-                    if (versionNumber == null) {
-                        object = ocflRepo.getObject(ObjectVersionId.head(ocflObjectId));
-                    } else {
-                        object = ocflRepo.getObject(ObjectVersionId.version(ocflObjectId, versionNumber));
-                    }
+                    final var object = ocflRepo.getObject(ObjectVersionId.version(ocflObjectId, versionNumber));
                     if (object.containsFile(path.path)) {
                         return Optional.of(object.getFile(path.path).getStream());
                     }

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -20,6 +20,7 @@ package org.fcrepo.storage.ocfl;
 
 import java.io.InputStream;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 /**
  * Session interface over an OCFL object. Changes to the object are accumulated in a staging directory until the
@@ -73,6 +74,16 @@ public interface OcflObjectSession {
     ResourceHeaders readHeaders(final String resourceId);
 
     /**
+     * Reads a specfic version of a resource's header file.
+     *
+     * @param resourceId the Fedora resource id to read
+     * @param versionNumber the version to read
+     * @return the resource's headers
+     * @throws NotFoundException if the resource cannot be found
+     */
+    ResourceHeaders readHeaders(final String resourceId, final String versionNumber);
+
+    /**
      * Reads a resource's content.
      *
      * @param resourceId the Fedora resource id to read
@@ -80,6 +91,25 @@ public interface OcflObjectSession {
      * @throws NotFoundException if the resource cannot be found
      */
     ResourceContent readContent(final String resourceId);
+
+    /**
+     * Reads a specific version of a resource's content.
+     *
+     * @param resourceId the Fedora resource id to read
+     * @param versionNumber the version to read
+     * @return the resource's content
+     * @throws NotFoundException if the resource cannot be found
+     */
+    ResourceContent readContent(final String resourceId, final String versionNumber);
+
+    /**
+     * List all of the versions associated to the resource in chrolological order.
+     *
+     * @param resourceId the Fedora resource id
+     * @return list of versions
+     * @throws NotFoundException if the resource cannot be found
+     */
+    List<OcflVersionInfo> listVersions(final String resourceId);
 
     /**
      * Sets the timestamp that's stamped on the OCFL version. If this value is not set, the current system time

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSessionFactory.java
@@ -43,4 +43,9 @@ public interface OcflObjectSessionFactory {
      */
     Optional<OcflObjectSession> existingSession(final String sessionId);
 
+    /**
+     * Closes the underlying OCFL repository, and aborts all active sessions.
+     */
+    void close();
+
 }

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflVersionInfo.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflVersionInfo.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.storage.ocfl;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Contains OCFL version metadata for a resource version.
+ *
+ * @author pwinckles
+ */
+public class OcflVersionInfo {
+
+    private final String resourceId;
+    private final String ocflObjectId;
+    private final String versionNumber;
+    private final Instant created;
+
+    public OcflVersionInfo(final String resourceId,
+                           final String ocflObjectId,
+                           final String versionNumber,
+                           final Instant created) {
+        this.resourceId = resourceId;
+        this.ocflObjectId = ocflObjectId;
+        this.versionNumber = versionNumber;
+        this.created = created;
+    }
+
+    /**
+     * @return the resourceId of the resource the version is for
+     */
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    /**
+     * @return the OCFL object id the resource is in
+     */
+    public String getOcflObjectId() {
+        return ocflObjectId;
+    }
+
+    /**
+     * @return the OCFL version number of the version
+     */
+    public String getVersionNumber() {
+        return versionNumber;
+    }
+
+    /**
+     * @return the timestamp when the version was created
+     */
+    public Instant getCreated() {
+        return created;
+    }
+
+    @Override
+    public String toString() {
+        return "OcflVersionInfo{" +
+                "resourceId='" + resourceId + '\'' +
+                ", ocflObjectId='" + ocflObjectId + '\'' +
+                ", versionNumber='" + versionNumber + '\'' +
+                ", created=" + created +
+                '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final OcflVersionInfo that = (OcflVersionInfo) o;
+        return Objects.equals(resourceId, that.resourceId) &&
+                Objects.equals(ocflObjectId, that.ocflObjectId) &&
+                Objects.equals(versionNumber, that.versionNumber) &&
+                Objects.equals(created, that.created);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceId, ocflObjectId, versionNumber, created);
+    }
+
+}

--- a/src/main/java/org/fcrepo/storage/ocfl/ResourceContent.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/ResourceContent.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.storage.ocfl;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 import java.util.Optional;
@@ -70,10 +71,10 @@ public class ResourceContent implements AutoCloseable {
     /**
      * Closes the underlying resource content stream.
      *
-     * @throws Exception if the stream is not closed cleanly
+     * @throws IOException if the stream is not closed cleanly
      */
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         if (contentStream.isPresent()) {
             contentStream.get().close();
         }

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -109,6 +110,17 @@ public class DefaultOcflObjectSessionFactoryTest {
         final var session2 = sessionFactory.existingSession(session1.sessionId());
 
         assertTrue(session2.isEmpty());
+    }
+
+    @Test
+    public void closeFactoryAndAllActiveSessions() {
+        final var session1 = sessionFactory.newSession("obj1");
+        final var session2 = sessionFactory.newSession("obj2");
+
+        sessionFactory.close();
+
+        assertFalse(session1.isOpen());
+        assertFalse(session2.isOpen());
     }
 
 }

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -632,11 +632,8 @@ public class DefaultOcflObjectSessionTest {
 
     @Test(expected = NotFoundException.class)
     public void throwExceptionWhenListingVersionsOnResourceThatDoesNotExist() {
+        close(defaultAg());
         final var session = sessionFactory.newSession(DEFAULT_AG_ID);
-
-        write(session, defaultAg());
-        session.commit();
-
         session.listVersions(DEFAULT_AG_BINARY_ID);
     }
 


### PR DESCRIPTION
While I was integrating this library into `migration-utils` I discovered that I needed a few additional features.

This PR adds:

1. Adds APIs for listing and read resource versions
1. A close method to the session factory that closes the OCFL client and aborts any active sessions