### PR TITLE
Add remaining features for feature parity with fcrepo-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>2.22.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,14 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>edu.wisc.library.ocfl</groupId>
       <artifactId>ocfl-java-core</artifactId>
-      <version>0.0.4-SNAPSHOT</version>
+      <version>0.0.5-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -71,6 +71,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.11</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.11</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/src/main/java/org/fcrepo/storage/ocfl/CommitType.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/CommitType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.storage.ocfl;
+
+/**
+ * Options for defining the behavior when performing a commit to the persistent storage layer.
+ *
+ * @author bbpennel
+ */
+public enum CommitType {
+    /* Commit unversioned content */
+    UNVERSIONED,
+    /* Commit a new version */
+    NEW_VERSION
+}

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import edu.wisc.library.ocfl.api.OcflObjectUpdater;
-import edu.wisc.library.ocfl.api.OcflObjectVersion;
 import edu.wisc.library.ocfl.api.OcflOption;
 import edu.wisc.library.ocfl.api.OcflRepository;
 import edu.wisc.library.ocfl.api.model.FileChangeType;
@@ -326,12 +325,7 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
         try {
             if (!(deleteObject && isOpen())) {
                 if (ocflRepo.containsObject(ocflObjectId)) {
-                    final OcflObjectVersion object;
-                    if (versionNumber == null) {
-                        object = ocflRepo.getObject(ObjectVersionId.head(ocflObjectId));
-                    } else {
-                        object = ocflRepo.getObject(ObjectVersionId.version(ocflObjectId, versionNumber));
-                    }
+                    final var object = ocflRepo.getObject(ObjectVersionId.version(ocflObjectId, versionNumber));
                     if (object.containsFile(path.path)) {
                         return Optional.of(object.getFile(path.path).getStream());
                     }

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -64,7 +64,8 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                                            final String defaultVersionUserAddress) {
         this.ocflRepo = Objects.requireNonNull(ocflRepo, "ocflRepo cannot be null");
         this.stagingRoot = Objects.requireNonNull(stagingRoot, "stagingRoot cannot be null");
-        this.headerReader = objectMapper.readerFor(ResourceHeaders.class);
+        this.headerReader = Objects.requireNonNull(objectMapper, "objectMapper cannot be null")
+                .readerFor(ResourceHeaders.class);
         this.headerWriter = objectMapper.writerFor(ResourceHeaders.class);
         this.defaultCommitType = Objects.requireNonNull(defaultCommitType, "defaultCommitType cannot be null");
         this.defaultVersionMessage = defaultVersionMessage;

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -19,13 +19,14 @@
 package org.fcrepo.storage.ocfl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import edu.wisc.library.ocfl.api.OcflRepository;
+import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,9 +40,10 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultOcflObjectSessionFactory.class);
 
-    private final OcflRepository ocflRepo;
+    private final MutableOcflRepository ocflRepo;
     private final Path stagingRoot;
     private final ObjectMapper objectMapper;
+    private final CommitType defaultCommitType;
     private final String defaultVersionMessage;
     private final String defaultVersionUserName;
     private final String defaultVersionUserAddress;
@@ -50,15 +52,17 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
 
     private boolean closed = false;
 
-    public DefaultOcflObjectSessionFactory(final OcflRepository ocflRepo,
+    public DefaultOcflObjectSessionFactory(final MutableOcflRepository ocflRepo,
                                            final Path stagingRoot,
                                            final ObjectMapper objectMapper,
+                                           final CommitType defaultCommitType,
                                            final String defaultVersionMessage,
                                            final String defaultVersionUserName,
                                            final String defaultVersionUserAddress) {
-        this.ocflRepo = ocflRepo;
-        this.stagingRoot = stagingRoot;
-        this.objectMapper = objectMapper;
+        this.ocflRepo = Objects.requireNonNull(ocflRepo, "ocflRepo cannot be null");
+        this.stagingRoot = Objects.requireNonNull(stagingRoot, "stagingRoot cannot be null");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper cannot be null");
+        this.defaultCommitType = Objects.requireNonNull(defaultCommitType, "defaultCommitType cannot be null");
         this.defaultVersionMessage = defaultVersionMessage;
         this.defaultVersionUserName = defaultVersionUserName;
         this.defaultVersionUserAddress = defaultVersionUserAddress;
@@ -76,6 +80,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                 ocflObjectId,
                 stagingRoot.resolve(sessionId),
                 objectMapper,
+                defaultCommitType,
                 () -> sessions.remove(sessionId)
         );
 

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -19,6 +19,8 @@
 package org.fcrepo.storage.ocfl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +44,8 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
 
     private final MutableOcflRepository ocflRepo;
     private final Path stagingRoot;
-    private final ObjectMapper objectMapper;
+    private final ObjectReader headerReader;
+    private final ObjectWriter headerWriter;
     private final CommitType defaultCommitType;
     private final String defaultVersionMessage;
     private final String defaultVersionUserName;
@@ -61,7 +64,8 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                                            final String defaultVersionUserAddress) {
         this.ocflRepo = Objects.requireNonNull(ocflRepo, "ocflRepo cannot be null");
         this.stagingRoot = Objects.requireNonNull(stagingRoot, "stagingRoot cannot be null");
-        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper cannot be null");
+        this.headerReader = objectMapper.readerFor(ResourceHeaders.class);
+        this.headerWriter = objectMapper.writerFor(ResourceHeaders.class);
         this.defaultCommitType = Objects.requireNonNull(defaultCommitType, "defaultCommitType cannot be null");
         this.defaultVersionMessage = defaultVersionMessage;
         this.defaultVersionUserName = defaultVersionUserName;
@@ -79,7 +83,8 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                 ocflRepo,
                 ocflObjectId,
                 stagingRoot.resolve(sessionId),
-                objectMapper,
+                headerReader,
+                headerWriter,
                 defaultCommitType,
                 () -> sessions.remove(sessionId)
         );

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -46,7 +46,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
     private final Path stagingRoot;
     private final ObjectReader headerReader;
     private final ObjectWriter headerWriter;
-    private final CommitType defaultCommitType;
+    private CommitType defaultCommitType;
     private final String defaultVersionMessage;
     private final String defaultVersionUserName;
     private final String defaultVersionUserAddress;
@@ -122,6 +122,15 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
         if (closed) {
             throw new IllegalStateException("The session factory is closed!");
         }
+    }
+
+    /**
+     * Allows the default CommitType to be changed at run time -- useful for testing.
+     *
+     * @param defaultCommitType commit type
+     */
+    public void setDefaultCommitType(final CommitType defaultCommitType) {
+        this.defaultCommitType = Objects.requireNonNull(defaultCommitType, "defaultCommitType cannot be null");
     }
 
 }

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -135,6 +135,13 @@ public interface OcflObjectSession {
     void versionMessage(final String message);
 
     /**
+     * Sets the commit behavior -- create a new version or update the mutable HEAD.
+     *
+     * @param commitType the commit behavior
+     */
+    void commitType(final CommitType commitType);
+
+    /**
      * Commits the session, persisting all changes to a new OCFL version.
      */
     void commit();

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -66,10 +66,10 @@ public interface OcflObjectSession extends AutoCloseable {
     void deleteResource(final String resourceId);
 
     /**
-     * Indicates if the resource exists.
+     * Indicates if the resource exists in the session
      *
      * @param resourceId the Fedora resource id
-     * @return true if the resouce exists
+     * @return true if the resource exists in the session
      */
     boolean containsResource(final String resourceId);
 
@@ -83,10 +83,10 @@ public interface OcflObjectSession extends AutoCloseable {
     ResourceHeaders readHeaders(final String resourceId);
 
     /**
-     * Reads a specfic version of a resource's header file.
+     * Reads a specific version of a resource's header file.
      *
      * @param resourceId the Fedora resource id to read
-     * @param versionNumber the version to read
+     * @param versionNumber the version to read, or null for HEAD
      * @return the resource's headers
      * @throws NotFoundException if the resource cannot be found
      */
@@ -105,7 +105,7 @@ public interface OcflObjectSession extends AutoCloseable {
      * Reads a specific version of a resource's content.
      *
      * @param resourceId the Fedora resource id to read
-     * @param versionNumber the version to read
+     * @param versionNumber the version to read, or null for HEAD
      * @return the resource's content
      * @throws NotFoundException if the resource cannot be found
      */

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -20,6 +20,7 @@ package org.fcrepo.storage.ocfl;
 
 import java.io.InputStream;
 import java.time.OffsetDateTime;
+import java.util.List;
 
 /**
  * Session interface over an OCFL object. Changes to the object are accumulated in a staging directory until the
@@ -73,6 +74,16 @@ public interface OcflObjectSession {
     ResourceHeaders readHeaders(final String resourceId);
 
     /**
+     * Reads a specfic version of a resource's header file.
+     *
+     * @param resourceId the Fedora resource id to read
+     * @param versionNumber the version to read
+     * @return the resource's headers
+     * @throws NotFoundException if the resource cannot be found
+     */
+    ResourceHeaders readHeaders(final String resourceId, final String versionNumber);
+
+    /**
      * Reads a resource's content.
      *
      * @param resourceId the Fedora resource id to read
@@ -80,6 +91,25 @@ public interface OcflObjectSession {
      * @throws NotFoundException if the resource cannot be found
      */
     ResourceContent readContent(final String resourceId);
+
+    /**
+     * Reads a specific version of a resource's content.
+     *
+     * @param resourceId the Fedora resource id to read
+     * @param versionNumber the version to read
+     * @return the resource's content
+     * @throws NotFoundException if the resource cannot be found
+     */
+    ResourceContent readContent(final String resourceId, final String versionNumber);
+
+    /**
+     * List all of the versions associated to the resource in chrolological order.
+     *
+     * @param resourceId the Fedora resource id
+     * @return list of versions
+     * @throws NotFoundException if the resource cannot be found
+     */
+    List<OcflVersionInfo> listVersions(final String resourceId);
 
     /**
      * Sets the timestamp that's stamped on the OCFL version. If this value is not set, the current system time

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -21,6 +21,7 @@ package org.fcrepo.storage.ocfl;
 import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Session interface over an OCFL object. Changes to the object are accumulated in a staging directory until the
@@ -110,6 +111,13 @@ public interface OcflObjectSession {
      * @throws NotFoundException if the resource cannot be found
      */
     List<OcflVersionInfo> listVersions(final String resourceId);
+
+    /**
+     * Returns the headers for all of the resources contained within an OCFL object. The results are unordered.
+     *
+     * @return resource headers
+     */
+    Stream<ResourceHeaders> streamResourceHeaders();
 
     /**
      * Sets the timestamp that's stamped on the OCFL version. If this value is not set, the current system time

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  *
  * @author pwinckles
  */
-public interface OcflObjectSession {
+public interface OcflObjectSession extends AutoCloseable {
 
     /**
      * @return the id of the session
@@ -64,6 +64,14 @@ public interface OcflObjectSession {
      * @param resourceId the Fedora resource id of the resource to delete
      */
     void deleteResource(final String resourceId);
+
+    /**
+     * Indicates if the resource exists.
+     *
+     * @param resourceId the Fedora resource id
+     * @return true if the resouce exists
+     */
+    boolean containsResource(final String resourceId);
 
     /**
      * Reads a resource's header file.

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSessionFactory.java
@@ -43,4 +43,9 @@ public interface OcflObjectSessionFactory {
      */
     Optional<OcflObjectSession> existingSession(final String sessionId);
 
+    /**
+     * Closes the underlying OCFL repository, and aborts all active sessions.
+     */
+    void close();
+
 }

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflVersionInfo.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflVersionInfo.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.storage.ocfl;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Contains OCFL version metadata for a resource version.
+ *
+ * @author pwinckles
+ */
+public class OcflVersionInfo {
+
+    private final String resourceId;
+    private final String ocflObjectId;
+    private final String versionNumber;
+    private final Instant created;
+
+    public OcflVersionInfo(final String resourceId,
+                           final String ocflObjectId,
+                           final String versionNumber,
+                           final Instant created) {
+        this.resourceId = resourceId;
+        this.ocflObjectId = ocflObjectId;
+        this.versionNumber = versionNumber;
+        this.created = created;
+    }
+
+    /**
+     * @return the resourceId of the resource the version is for
+     */
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    /**
+     * @return the OCFL object id the resource is in
+     */
+    public String getOcflObjectId() {
+        return ocflObjectId;
+    }
+
+    /**
+     * @return the OCFL version number of the version
+     */
+    public String getVersionNumber() {
+        return versionNumber;
+    }
+
+    /**
+     * @return the timestamp when the version was created
+     */
+    public Instant getCreated() {
+        return created;
+    }
+
+    @Override
+    public String toString() {
+        return "OcflVersionInfo{" +
+                "resourceId='" + resourceId + '\'' +
+                ", ocflObjectId='" + ocflObjectId + '\'' +
+                ", versionNumber='" + versionNumber + '\'' +
+                ", created=" + created +
+                '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final OcflVersionInfo that = (OcflVersionInfo) o;
+        return Objects.equals(resourceId, that.resourceId) &&
+                Objects.equals(ocflObjectId, that.ocflObjectId) &&
+                Objects.equals(versionNumber, that.versionNumber) &&
+                Objects.equals(created, that.created);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceId, ocflObjectId, versionNumber, created);
+    }
+
+}

--- a/src/main/java/org/fcrepo/storage/ocfl/PersistencePaths.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/PersistencePaths.java
@@ -128,6 +128,16 @@ public final class PersistencePaths {
         return new PersistencePaths(contentPath, headerPath);
     }
 
+    /**
+     * Returns true if the path is a resource header file.
+     *
+     * @param path file path
+     * @return true if it's a resource header file
+     */
+    public static boolean isHeaderFile(final String path) {
+        return path.startsWith(HEADER_DIR);
+    }
+
     private static String resolveContentPath(final boolean isContainer, final IdInfo info) {
         if (info.isRoot) {
             if (isContainer) {

--- a/src/main/java/org/fcrepo/storage/ocfl/ResourceContent.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/ResourceContent.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.storage.ocfl;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
 import java.util.Optional;
@@ -70,10 +71,10 @@ public class ResourceContent implements AutoCloseable {
     /**
      * Closes the underlying resource content stream.
      *
-     * @throws Exception if the stream is not closed cleanly
+     * @throws IOException if the stream is not closed cleanly
      */
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         if (contentStream.isPresent()) {
             contentStream.get().close();
         }

--- a/src/main/java/org/fcrepo/storage/ocfl/ResourceHeaders.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/ResourceHeaders.java
@@ -20,6 +20,7 @@ package org.fcrepo.storage.ocfl;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -51,6 +52,10 @@ public class ResourceHeaders {
     private boolean objectRoot;
     private boolean deleted;
     private String contentPath;
+
+    public ResourceHeaders() {
+        digests = new ArrayList<>();
+    }
 
     /**
      * @return the fedora id
@@ -161,7 +166,11 @@ public class ResourceHeaders {
      * @param digests the digests to set
      */
     public void setDigests(final Collection<URI> digests) {
-        this.digests = digests;
+        if (digests == null) {
+            this.digests = new ArrayList<>();
+        } else {
+            this.digests = digests;
+        }
     }
 
     /**

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -109,6 +110,17 @@ public class DefaultOcflObjectSessionFactoryTest {
         final var session2 = sessionFactory.existingSession(session1.sessionId());
 
         assertTrue(session2.isEmpty());
+    }
+
+    @Test
+    public void closeFactoryAndAllActiveSessions() {
+        final var session1 = sessionFactory.newSession("obj1");
+        final var session2 = sessionFactory.newSession("obj2");
+
+        sessionFactory.close();
+
+        assertFalse(session1.isOpen());
+        assertFalse(session2.isOpen());
     }
 
 }

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
@@ -21,7 +21,7 @@ package org.fcrepo.storage.ocfl;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import edu.wisc.library.ocfl.api.OcflRepository;
+import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
 import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
@@ -52,7 +52,7 @@ public class DefaultOcflObjectSessionFactoryTest {
     private Path ocflRoot;
     private Path sessionStaging;
 
-    private OcflRepository ocflRepo;
+    private MutableOcflRepository ocflRepo;
     private OcflObjectSessionFactory sessionFactory;
 
     private static final String DEFAULT_MESSAGE = "F6 migration";
@@ -73,7 +73,7 @@ public class DefaultOcflObjectSessionFactoryTest {
                 .logicalPathMapper(logicalPathMapper)
                 .storage(FileSystemOcflStorage.builder().repositoryRoot(ocflRoot).build())
                 .workDir(ocflTemp)
-                .build();
+                .buildMutable();
 
         final var objectMapper = new ObjectMapper()
                 .configure(WRITE_DATES_AS_TIMESTAMPS, false)
@@ -81,7 +81,7 @@ public class DefaultOcflObjectSessionFactoryTest {
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         sessionFactory = new DefaultOcflObjectSessionFactory(ocflRepo, sessionStaging, objectMapper,
-                DEFAULT_MESSAGE, DEFAULT_USER, DEFAULT_ADDRESS);
+                CommitType.NEW_VERSION, DEFAULT_MESSAGE, DEFAULT_USER, DEFAULT_ADDRESS);
     }
 
     @Test

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -632,11 +632,8 @@ public class DefaultOcflObjectSessionTest {
 
     @Test(expected = NotFoundException.class)
     public void throwExceptionWhenListingVersionsOnResourceThatDoesNotExist() {
+        close(defaultAg());
         final var session = sessionFactory.newSession(DEFAULT_AG_ID);
-
-        write(session, defaultAg());
-        session.commit();
-
         session.listVersions(DEFAULT_AG_BINARY_ID);
     }
 


### PR DESCRIPTION
This PR adds the following features:

1. Read previous resource versions
1. List resource versions
1. Add the OCFL digest to the resource headers
1. Write to the mutable HEAD
1. Iterate over the resources within an object

`fcrepo-storage-ocfl` should now have all of the features, and a few extra, that are currently in core.