### PR TITLE
remove exception from close signature

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -173,4 +173,7 @@ public interface OcflObjectSession extends AutoCloseable {
      */
     boolean isOpen();
 
+    @Override
+    void close();
+
 }


### PR DESCRIPTION
Overrides the `AutoCloseable.close()` signature to remove `Exception`. Implementations will never throw checked exceptions.