### PR TITLE
Use last update timestamp for touch timestamp

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -515,26 +515,26 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
                 && !Objects.equals(rootResourceId(), headers.getId())
                 && !InteractionModel.ACL.getUri().equals(headers.getInteractionModel())) {
             LOG.debug("Touching AG {} after updating {}", rootResourceId(), headers.getId());
-            touchResource(rootResourceId());
+            touchResource(rootResourceId(), headers.getLastModifiedDate());
         }
 
         if (InteractionModel.NON_RDF_DESCRIPTION.getUri().equals(headers.getInteractionModel())) {
             LOG.debug("Touching binary {} after updating {}", headers.getParent(), headers.getId());
-            touchResource(headers.getParent());
+            touchResource(headers.getParent(), headers.getLastModifiedDate());
         } else if (InteractionModel.NON_RDF.getUri().equals(headers.getInteractionModel())) {
             final var descriptionId = headers.getId() + "/" + PersistencePaths.FCR_METADATA;
             LOG.debug("Touching binary description {} after updating {}", descriptionId, headers.getId());
             try {
-                touchResource(descriptionId);
+                touchResource(descriptionId, headers.getLastModifiedDate());
             } catch (NotFoundException e) {
                 // Ignore this exception because it just means that the binary description hasn't been created yet
             }
         }
     }
 
-    private void touchResource(final String resourceId) {
+    private void touchResource(final String resourceId, final Instant timestamp) {
         final var headers = readHeaders(resourceId);
-        headers.setLastModifiedDate(Instant.now());
+        headers.setLastModifiedDate(timestamp);
 
         final var headerPath = encode(PersistencePaths.headerPath(rootResourceId(), resourceId));
         final var headerDst = createStagingPath(headerPath);


### PR DESCRIPTION
When a resource is touched as a result of updating a related resource, the timestamp that is used should be the last update timestamp of the related resource and not `now`.